### PR TITLE
fixed a possible error in when used <id>

### DIFF
--- a/MGBox/MGLayoutManager.m
+++ b/MGBox/MGLayoutManager.m
@@ -4,6 +4,7 @@
 
 #import "MGLayoutManager.h"
 #import "MGScrollView.h"
+#import "MGLayoutBox.h"
 
 @interface MGLayoutManager ()
 
@@ -37,7 +38,7 @@
   }
 
   // children layout first
-  for (id box in container.boxes) {
+  for (id <MGLayoutBox> box in container.boxes) {
     [box layout];
   }
 
@@ -101,7 +102,7 @@
   }
 
   // children layout first
-  for (id box in container.boxes) {
+  for (id <MGLayoutBox> box in container.boxes) {
     [box layout];
   }
 


### PR DESCRIPTION
Multiple methods named 'layout:' found with mismatched result, parameter type or attributes if another class also have a method "layout"  in ARC
