### PR TITLE
MGMushParser should use original font if bold/italic version missing

### DIFF
--- a/MGBox/MGMushParser.m
+++ b/MGBox/MGMushParser.m
@@ -171,13 +171,13 @@
   CTFontRef ctBold = CTFontCreateCopyWithSymbolicTraits(ctBase, 0, NULL,
       kCTFontBoldTrait, kCTFontBoldTrait);
   CFStringRef boldName = CTFontCopyName(ctBold, kCTFontPostScriptNameKey);
-  bold = [UIFont fontWithName:(__bridge NSString *)boldName size:size];
+  bold = [UIFont fontWithName:(__bridge NSString *)boldName size:size] ?: font;
 
   // italic font
   CTFontRef ctItalic = CTFontCreateCopyWithSymbolicTraits(ctBase, 0, NULL,
       kCTFontItalicTrait, kCTFontItalicTrait);
   CFStringRef italicName = CTFontCopyName(ctItalic, kCTFontPostScriptNameKey);
-  italic = [UIFont fontWithName:(__bridge NSString *)italicName size:size];
+  italic = [UIFont fontWithName:(__bridge NSString *)italicName size:size] ?: font;
 
   monospace = [UIFont fontWithName:@"CourierNewPSMT" size:size];
 }


### PR DESCRIPTION
MGMushParser's `attributedStringFromMush:font:color:` method currently crashes if it is provided a custom UIFont that does not have a bold or italic counterpart.

This fix allows bold and italic text to fall back to the default style should either font be missing.
