### PR TITLE
Fix for CF objects leak in MGMushParser.m:setBaseFont

### DIFF
--- a/MGBox/MGMushParser.m
+++ b/MGBox/MGMushParser.m
@@ -180,6 +180,13 @@
   italic = [UIFont fontWithName:(__bridge NSString *)italicName size:size] ?: font;
 
   monospace = [UIFont fontWithName:@"CourierNewPSMT" size:size];
+  
+  // Release CF objects no longer needed
+  CFRelease(ctBase);
+  CFRelease(ctBold);
+  CFRelease(boldName);
+  CFRelease(ctItalic);
+  CFRelease(italicName);
 }
 
 #pragma mark - Getters


### PR DESCRIPTION
In **MGBox2/MGBox/MGMushParser.m:setBaseFont**, `boldName` and a few other CF objects were leaking due to the extra retains created by `CTFontCopyName` and other functions. I confirmed the leak on my iPhone by creating mush multilines.

This patch releases the no longer needed objects using `CFRelease` at the end of `setBaseFont`'s execution.
