### PR TITLE
Solves issue #58

### DIFF
--- a/MGBoxKit/MGScrollView.m
+++ b/MGBoxKit/MGScrollView.m
@@ -115,7 +115,7 @@
 }
 
 - (void)layoutSubviews {
-
+  [super layoutSubviews];
   // deal with fixed position
   for (UIView <MGLayoutBox> *box in self.subviews) {
     if ([box conformsToProtocol:@protocol(MGLayoutBox)] && box.boxLayoutMode


### PR DESCRIPTION
Solves non-compiling issue for MGScrollView used from Interface Builder.

Original Stack Trace:
2014-03-22 19:53:50.134 MGBoxTest[27848:60b] **\* Assertion failure in -[MGScrollView layoutSublayersOfLayer:], /SourceCache/UIKit_Sim/UIKit-2935.137/UIView.m:8794
2014-03-22 19:53:50.137 MGBoxTest[27848:60b] **\* Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Auto Layout still required after executing -layoutSubviews. MGScrollView's implementation of -layoutSubviews needs to call super.'
**\* First throw call stack:
(
    0   CoreFoundation                      0x0000000101d8e495 **exceptionPreprocess + 165
    1   libobjc.A.dylib                     0x000000010170699e objc_exception_throw + 43
    2   CoreFoundation                      0x0000000101d8e31a +[NSException raise:format:arguments:] + 106
    3   Foundation                          0x00000001012a2f19 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 189
    4   UIKit                               0x0000000100313a3a -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 521
    5   QuartzCore                          0x0000000101bb7802 -[CALayer layoutSublayers] + 151
    6   QuartzCore                          0x0000000101bac369 _ZN2CA5Layer16layout_if_neededEPNS_11TransactionE + 363
    7   QuartzCore                          0x0000000101bb7736 -[CALayer layoutIfNeeded] + 162
    8   UIKit                               0x00000001003b9a22 -[UIViewController window:setupWithInterfaceOrientation:] + 264
    9   UIKit                               0x00000001002f0cad -[UIWindow _setRotatableClient:toOrientation:updateStatusBar:duration:force:isRotating:] + 4360
    10  UIKit                               0x00000001002efb9f -[UIWindow _setRotatableClient:toOrientation:updateStatusBar:duration:force:] + 36
    11  UIKit                               0x00000001002efaef -[UIWindow _setRotatableViewOrientation:updateStatusBar:duration:force:] + 101
    12  UIKit                               0x00000001002eedfe -[UIWindow _updateToInterfaceOrientation:duration:force:] + 377
    13  UIKit                               0x00000001003ad70a -[UIViewController _tryBecomeRootViewControllerInWindow:] + 147
    14  UIKit                               0x00000001002e9b1b -[UIWindow addRootViewControllerViewIfPossible] + 490
    15  UIKit                               0x00000001002e9c70 -[UIWindow _setHidden:forced:] + 282
    16  UIKit                               0x00000001002f2ffa -[UIWindow makeKeyAndVisible] + 51
    17  UIKit                               0x00000001002aec98 -[UIApplication _callInitializationDelegatesForURL:payload:suspended:] + 1788
    18  UIKit                               0x00000001002b2a0c -[UIApplication _runWithURL:payload:launchOrientation:statusBarStyle:statusBarHidden:] + 660
    19  UIKit                               0x00000001002c3d4c -[UIApplication handleEvent:withNewEvent:] + 3189
    20  UIKit                               0x00000001002c4216 -[UIApplication sendEvent:] + 79
    21  UIKit                               0x00000001002b4086 _UIApplicationHandleEvent + 578
    22  GraphicsServices                    0x0000000103f0771a _PurpleEventCallback + 762
    23  GraphicsServices                    0x0000000103f071e1 PurpleEventCallback + 35
    24  CoreFoundation                      0x0000000101d10679 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION** + 41
    25  CoreFoundation                      0x0000000101d1044e __CFRunLoopDoSource1 + 478
    26  CoreFoundation                      0x0000000101d39903 __CFRunLoopRun + 1939
    27  CoreFoundation                      0x0000000101d38d83 CFRunLoopRunSpecific + 467
    28  UIKit                               0x00000001002b22e1 -[UIApplication _run] + 609
    29  UIKit                               0x00000001002b3e33 UIApplicationMain + 1010
    30  MGBoxTest                           0x0000000100020a83 main + 115
    31  libdyld.dylib                       0x00000001024265fd start + 1
    32  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
