### PR TITLE
Update MGLine.m

### DIFF
--- a/MGBoxKit/MGLine.m
+++ b/MGBoxKit/MGLine.m
@@ -495,6 +495,12 @@
           if ((int)size.height % 2 && !((int)self.height % 2)) {
             size.height += 1;
           }
+          
+          // counter weird (boundingRectWithSize?) bug, where width can exceed maxSize:
+          if (size.width > maxSize.width) {
+            size.width = maxSize.width;
+          }
+
           label.size = size;
 
           used += (label.width);


### PR DESCRIPTION
In case of multiline, it can happen that label.width exceeds maxSize; without this commit the label is displayed but without text (just empty)! This commit fixes this issue.
