### PR TITLE
added scrollsHorizontally feature for grid layouts

### DIFF
--- a/MGBoxKit/MGBox.m
+++ b/MGBoxKit/MGBox.m
@@ -23,6 +23,7 @@
 @synthesize attachedTo, replacementFor, sizingMode, minWidth;
 @synthesize fixedPosition, zIndex, layingOut, slideBoxesInFromEmpty;
 @synthesize dontLayoutChildren;
+@synthesize scrollsHorizontally;
 
 // MGLayoutBox protocol optionals
 @synthesize cacheKey;

--- a/MGBoxKit/MGButton.m
+++ b/MGBoxKit/MGButton.m
@@ -21,6 +21,7 @@
 @synthesize attachedTo, replacementFor, sizingMode, minWidth;
 @synthesize fixedPosition, zIndex, layingOut, slideBoxesInFromEmpty;
 @synthesize dontLayoutChildren;
+@synthesize scrollsHorizontally;
 
 - (id)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];

--- a/MGBoxKit/MGLayoutBox.h
+++ b/MGBoxKit/MGLayoutBox.h
@@ -241,6 +241,7 @@ box with another.
 @property (nonatomic, assign) BOOL dontLayoutChildren;
 @property (nonatomic, assign) BOOL slideBoxesInFromEmpty;
 @property (nonatomic, assign) BOOL layingOut;
+@property (nonatomic, assign) BOOL scrollsHorizontally;
 
 /**
 This is the main layout method, which should be called on a container box once

--- a/MGBoxKit/MGScrollView.m
+++ b/MGBoxKit/MGScrollView.m
@@ -31,6 +31,7 @@
 @synthesize attachedTo, replacementFor, sizingMode, minWidth;
 @synthesize fixedPosition, zIndex, layingOut, slideBoxesInFromEmpty;
 @synthesize dontLayoutChildren;
+@synthesize scrollsHorizontally;
 
 // MGLayoutBox protocol optionals
 @synthesize onAppear, onDisappear;


### PR DESCRIPTION
not satisfied with implementation as final: will hopefully rewrite in future so that new MGBoxes are added by row, not column. current implementation is basically the original vertical-scrolling algorithm, just with reversed x,y axises.

to enable, use MGLayoutGridStyle and set grid.scrollsHorizontally = true.
