### PR TITLE
Fix a layout issue when using shrink wrap sizing mode

### DIFF
--- a/MGBoxKit/MGLayoutManager.m
+++ b/MGBoxKit/MGLayoutManager.m
@@ -606,7 +606,7 @@ CGFloat roundToPixel(CGFloat value) {
           : container.size;
     if (container.sizingMode == MGResizingShrinkWrap) {
         newSize = (CGSize){
-              container.leftPadding + container.rightPadding,
+              MAX(container.leftPadding + container.rightPadding, container.minWidth),
               container.topPadding + container.bottomPadding
         };
     } else {


### PR DESCRIPTION
Apply all codes in master branch with demo app in development branch, you will notice that when photo boxes are delete, the table grids won't be moved up appropriately.

So, set resizing mode to MGResizingShrinkWrap for photo grids. But now, when all photo boxes are removed, tap Add box, and you will notice that the Add box will be positioned under the new added photo box item instead of the same row.

To resolve this issue, we can set minWidth of photo grids and compare with minWidth of container in MGLayoutManager.

Following is my updates for DemoViewController after integrated with MGBoxKit in master branch,
```objc
photosGrid.minWidth = self.view.bounds.size.width;
photosGrid.sizingMode = MGResizingShrinkWrap;
```
