### PR TITLE
Take keepFirstResponderAboveKeyboard property effect when keyboard will disappear

### DIFF
--- a/MGBoxKit/MGScrollView.m
+++ b/MGBoxKit/MGScrollView.m
@@ -271,6 +271,11 @@
 }
 
 - (void)keyboardWillDisappear:(NSNotification *)note {
+
+  if (!self.keepFirstResponderAboveKeyboard) {
+      return;
+  }
+
   double d = [note.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
   int curve = [note.userInfo[UIKeyboardAnimationCurveUserInfoKey] intValue];
   [UIView animateWithDuration:d delay:0 options:curve animations:^{


### PR DESCRIPTION
When MGScrollView needs ignore keyboard event, the property - keepFirstResponderAboveKeyboard - should be set to NO. While in the method - keyboardWillDisappear, the current existing code doesn't check this property.

So, please accept the PR when you examined issue. Thanks.