### PR TITLE
Use UIView+MGEasyFrame categorie only in MGBoxKit files

### DIFF
--- a/MGBoxKit/MGBase.h
+++ b/MGBoxKit/MGBase.h
@@ -5,5 +5,4 @@
 #define CLAMP(x,low,high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
 #import <MGEvents/MGEvents.h>
-#import "UIView+MGEasyFrame.h"
 #import "UIResponder+FirstResponder.h"

--- a/MGBoxKit/MGBox.m
+++ b/MGBoxKit/MGBox.m
@@ -7,6 +7,7 @@
 #import "MGBox.h"
 #import "MGLayoutManager.h"
 #import "UIColor+MGExpanded.h"
+#import "UIView+MGEasyFrame.h"
 
 @implementation MGBox {
   BOOL fixedPositionEstablished;

--- a/MGBoxKit/MGButton.m
+++ b/MGBoxKit/MGButton.m
@@ -6,6 +6,7 @@
 
 #import "MGButton.h"
 #import "MGLayoutManager.h"
+#import "UIView+MGEasyFrame.h"
 
 @implementation MGButton {
   BOOL fixedPositionEstablished;

--- a/MGBoxKit/MGLayoutManager.m
+++ b/MGBoxKit/MGLayoutManager.m
@@ -6,6 +6,7 @@
 #import "MGScrollView.h"
 #import "MGBoxProvider.h"
 #import <tgmath.h>
+#import "UIView+MGEasyFrame.h"
 
 CGFloat roundToPixel(CGFloat value) {
   return UIScreen.mainScreen.scale == 1 ? round(value) : round(value * 2.0) / 2.0;

--- a/MGBoxKit/MGLine.m
+++ b/MGBoxKit/MGLine.m
@@ -9,6 +9,7 @@
 #import "MGMushParser.h"
 #import "NSAttributedString+MGTrim.h"
 #import "NSString+MGEasySize.h"
+#import "UIView+MGEasyFrame.h"
 
 @interface MGLine ()
 @property (nonatomic, retain) NSMutableArray *dontFit;

--- a/MGBoxKit/MGScrollView.m
+++ b/MGBoxKit/MGScrollView.m
@@ -7,6 +7,7 @@
 #import "MGScrollView.h"
 #import "MGLayoutManager.h"
 #import "MGBoxProvider.h"
+#import "UIView+MGEasyFrame.h"
 
 // default keyboardMargin
 #define KEYBOARD_MARGIN 8


### PR DESCRIPTION
@sobri909 
Please consider this PR.
You're UIView category can be duplicate with personal categories or other pod categories and create a conflict.
Please let us the choice to not use yours.